### PR TITLE
Add ansible playbook to automate the configuration steps 

### DIFF
--- a/ansible-playbook.yml
+++ b/ansible-playbook.yml
@@ -1,0 +1,47 @@
+---
+- hosts: all
+  become: yes
+  tasks:
+
+    - name: add fail2ban group
+      group:
+        name: fail2ban
+        state: present
+
+    - name: add zabbix user to fail2ban group
+      user:
+        name: zabbix
+        groups: fail2ban
+        append: yes
+
+    - name: add zabbix userparameter for fail2ban
+      tags:
+         - userparameter   
+      copy:
+        src: fail2ban.conf
+        dest: /etc/zabbix/zabbix_agentd.d/fail2ban.conf
+
+    - name: restart zabbix-agent
+      tags:
+         - userparameter   
+      service:
+        name: zabbix-agent
+        state: restarted
+
+    - name: create directory for scripts
+      file:
+        path: /root/scripts
+        state: directory
+
+    - name: create script to make the group ownership and permissions of fail2ban socket
+      template:
+        src: script/fail2ban-socket-perms.sh
+        dest: /root/scripts/fail2ban-socket-perms.sh
+        mode: a+x
+
+    - name: permissions over fail2ban socket cronjob
+      cron: 
+        name: set permissions for fail2ban socket
+        minute: 0
+        hour: '*'
+        job: /root/scripts/fail2ban-socket-perms.sh

--- a/script/fail2ban-socket-perms.sh
+++ b/script/fail2ban-socket-perms.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This script changes the group of the fail2ban socket to allow zabbix user to query about jails status
+# Will also give the group the permissions over the socket
+
+/bin/chown root:fail2ban /var/run/fail2ban/fail2ban.sock
+/bin/chmod g+rwx	/var/run/fail2ban/fail2ban.sock


### PR DESCRIPTION
This pull request add an ansible playbook that execute the following tasks:

* Add the fail2ban group
* Add the zabbix user to the fail2ban group
* Copy the zabbix userparameter configuration file for fail2ban
* Restart the zabbix-agent
* Copy a bash script to set the group ownership and permissions of fail2ban socket (using the same steps/commands specificied on the README)
* Add the bash script to a cronjob that ensures that the proper permissions over the socket across service restart and reboots.

I've found this playbook really helpful when you are deploying the Template across several servers at once.